### PR TITLE
Truncate data to a specific date range

### DIFF
--- a/onehealth_data_backend/preprocess.py
+++ b/onehealth_data_backend/preprocess.py
@@ -506,8 +506,8 @@ def _parse_date(date: str | np.datetime64 | None) -> np.datetime64 | None:
             raise ValueError("Date string must be in the format 'YYYY-MM-DD'.")
         try:
             date = np.datetime64(date, "ns")
-        except ValueError:
-            raise ValueError("Invalid date format.")
+        except ValueError as e:
+            raise ValueError(f"Invalid date value. Error: {e}")
 
     if not isinstance(date, np.datetime64):
         raise ValueError("Date must be of type string, np.datetime64, or None.")


### PR DESCRIPTION
This PR addresses issue #6 

The data can now be truncated starting from a given date, up to a specified end date, with both boundaries inclusive.

If the end date is `None`, then the data is truncated until the last date in the dataset.