### PR TITLE
Fix bug of updating file name after data truncation

### DIFF
--- a/onehealth_data_backend/preprocess.py
+++ b/onehealth_data_backend/preprocess.py
@@ -673,9 +673,13 @@ def _apply_preprocessing(
             end_date=truncate_date_to,
             var_name=truncate_date_vname,
         )
+
+        min_year = truncate_date_from[:4]
         max_time = dataset[truncate_date_vname].max().values
-        max_year = np.datetime64(max_time, "Y")
-        file_name_base += f"_{truncate_date_from[:4]}_{max_year}"
+        max_year = (
+            truncate_date_to[:4] if truncate_date_to else np.datetime64(max_time, "Y")
+        )
+        file_name_base += f"_{min_year}-{max_year}"
 
     return dataset, file_name_base
 

--- a/onehealth_data_backend/test/test_preprocess.py
+++ b/onehealth_data_backend/test/test_preprocess.py
@@ -864,12 +864,33 @@ def test_apply_preprocessing_upsample(get_dataset):
 def test_apply_preprocessing_truncate(get_dataset):
     fname_base = "test_data"
 
+    # case where end year is max year
     settings = {
         "truncate_date": True,
-        "truncate_date_from": "2025-01-01",
+        "truncate_date_from": "2024-01-01",
         "truncate_date_to": "2025-01-01",
         "truncate_date_vname": "time",
     }
+    # preprocess the data file
+    preprocessed_dataset, updated_fname = preprocess._apply_preprocessing(
+        get_dataset, fname_base, settings=settings
+    )
+
+    # check if the time dimension is retained
+    assert len(preprocessed_dataset["t2m"].time) == 2
+    assert len(preprocessed_dataset["tp"].time) == 2
+
+    # check if file name is updated
+    assert updated_fname == f"{fname_base}_2024-2025"
+
+    # case where end year < max year
+    settings = {
+        "truncate_date": True,
+        "truncate_date_from": "2024-01-01",
+        "truncate_date_to": "2024-01-01",
+        "truncate_date_vname": "time",
+    }
+
     # preprocess the data file
     preprocessed_dataset, updated_fname = preprocess._apply_preprocessing(
         get_dataset, fname_base, settings=settings
@@ -880,7 +901,27 @@ def test_apply_preprocessing_truncate(get_dataset):
     assert len(preprocessed_dataset["tp"].time) == 1
 
     # check if file name is updated
-    assert updated_fname == f"{fname_base}_2025_2025"
+    assert updated_fname == f"{fname_base}_2024-2024"
+
+    # case where end year is None
+    settings = {
+        "truncate_date": True,
+        "truncate_date_from": "2025-01-01",
+        "truncate_date_to": None,
+        "truncate_date_vname": "time",
+    }
+
+    # preprocess the data file
+    preprocessed_dataset, updated_fname = preprocess._apply_preprocessing(
+        get_dataset, fname_base, settings=settings
+    )
+
+    # check if the time dimension is reduced
+    assert len(preprocessed_dataset["t2m"].time) == 1
+    assert len(preprocessed_dataset["tp"].time) == 1
+
+    # check if file name is updated
+    assert updated_fname == f"{fname_base}_2025-2025"
 
 
 def test_preprocess_data_file_invalid(tmp_path):
@@ -915,6 +956,7 @@ def test_preprocess_data_file(tmp_path, get_dataset):
     settings = {
         "truncate_date": True,
         "truncate_date_from": "2025-01-01",
+        "truncate_date_to": "2025-01-01",
         "truncate_date_vname": "time",
     }
     # preprocess the data file
@@ -925,18 +967,18 @@ def test_preprocess_data_file(tmp_path, get_dataset):
     assert len(preprocessed_dataset["tp"].time) == 1
 
     # check if there is new file created
-    assert (tmp_path / "test_data_2025_2025.nc").exists()
-    with xr.open_dataset(tmp_path / "test_data_2025_2025.nc") as ds:
+    assert (tmp_path / "test_data_2025-2025.nc").exists()
+    with xr.open_dataset(tmp_path / "test_data_2025-2025.nc") as ds:
         assert len(ds["t2m"].time) == 1
         assert len(ds["tp"].time) == 1
 
     # check if file name ends with raw
-    (tmp_path / "test_data_2025_2025.nc").unlink()
+    (tmp_path / "test_data_2025-2025.nc").unlink()
     file_path = tmp_path / "test_data_raw.nc"
     get_dataset.to_netcdf(file_path)
 
     _ = preprocess.preprocess_data_file(file_path, settings)
-    assert (tmp_path / "test_data_2025_2025.nc").exists()
+    assert (tmp_path / "test_data_2025-2025.nc").exists()
 
 
 def test_aggregate_netcdf_nuts_invalid(tmp_path, get_dataset, get_nuts_data):


### PR DESCRIPTION
* Update file name after truncating data from a specific year to another year.
* Change `_` to `-` between `start` and `end` years to make it consistent with the naming convention (updated later by PR #25)