### PR TITLE
Update site_name to "Heiplanet Data" in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: One Health Platform
+site_name: Heiplanet Data
 site_url: https://ssciwr.github.io/heiplanet-data/
 repo_url: https://github.com/ssciwr/heiplanet-data
 repo_name: "ssciwr/heiplanet-data"


### PR DESCRIPTION
This pull request updates the `site_name` field in `mkdocs.yml` from `"One Health Platform"` to `"Heiplanet Data"` to correctly reflect the name and purpose of this repository.

Fixes #74.
