### PR TITLE
refactor architecture of the package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,22 @@
 ## Conda environment
 
 All dependencies for this project live in the **`heiplanet-data`** conda
-environment (created via miniforge at
-`/home/inga/miniforge3/envs/heiplanet-data`). The base environment does **not**
+environment (created via miniforge or another forge at
+`~/miniforge3/envs/heiplanet-data`). The base environment does **not**
 have `xarray`, `xesmf`, `cdo`, etc.
 
 **Always activate the environment** before running code or tests — do not call
 the environment's Python by its absolute path:
 
 ```bash
-source /home/inga/miniforge3/etc/profile.d/conda.sh
+source ~/miniforge3/etc/profile.d/conda.sh
 conda activate heiplanet-data
 ```
 
 Activation matters: some preprocessing steps shell out to command-line binaries
 (notably `cdo`, and `esmf`/`esmpy` for `xESMF` downsampling). Those binaries are
 installed in the environment's `bin/` directory. Invoking
-`/home/inga/miniforge3/envs/heiplanet-data/bin/python` directly runs the right
+`~/miniforge3/envs/heiplanet-data/bin/python` directly runs the right
 interpreter but does **not** put the environment's `bin/` on `PATH`, so
 `subprocess` calls fail with `FileNotFoundError: 'cdo'`. Activating the
 environment fixes this.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Conda environment
+
+All dependencies for this project live in the **`heiplanet-data`** conda
+environment (created via miniforge at
+`/home/inga/miniforge3/envs/heiplanet-data`). The base environment does **not**
+have `xarray`, `xesmf`, `cdo`, etc.
+
+**Always activate the environment** before running code or tests — do not call
+the environment's Python by its absolute path:
+
+```bash
+source /home/inga/miniforge3/etc/profile.d/conda.sh
+conda activate heiplanet-data
+```
+
+Activation matters: some preprocessing steps shell out to command-line binaries
+(notably `cdo`, and `esmf`/`esmpy` for `xESMF` downsampling). Those binaries are
+installed in the environment's `bin/` directory. Invoking
+`/home/inga/miniforge3/envs/heiplanet-data/bin/python` directly runs the right
+interpreter but does **not** put the environment's `bin/` on `PATH`, so
+`subprocess` calls fail with `FileNotFoundError: 'cdo'`. Activating the
+environment fixes this.
+
+## Running tests
+
+With the environment activated, from the repository root:
+
+```bash
+pytest                                   # full suite
+pytest heiplanet_data/test/test_preprocess.py -q   # one module
+```
+
+The test suite is expected to pass fully in an activated `heiplanet-data`
+environment. If `cdo`/`xesmf` tests fail with a missing-binary error, the
+environment is almost certainly not activated (or the optional deps were never
+installed — see `README.md` for the `conda install -c conda-forge esmf esmpy`
+and `python-cdo` steps).

--- a/heiplanet_data/preprocess.py
+++ b/heiplanet_data/preprocess.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Union, Dict, Any, Tuple, Literal
+from typing import TypeVar, Union, Dict, Any, Tuple, Literal, Callable
 import xarray as xr
 import numpy as np
 import warnings
@@ -1137,12 +1137,249 @@ def _replace_decimal_point(degree: float) -> str:
         return str(degree).replace(".", "p")
 
 
+# --- Preprocessing step registry -------------------------------------------
+# Each step has the signature
+#   (dataset, file_name_base, settings, logger) -> (dataset, file_name_base)
+# and registers itself with an explicit `order` that fixes the execution
+# sequence (and therefore the order of filename suffixes). To add a new
+# preprocessing method: write one @register_step function below and add its
+# keys to setting_schema.json and the settings JSON files. No edit to the
+# orchestrator `_apply_preprocessing` is needed.
+StepFn = Callable[
+    [xr.Dataset, str, Dict[str, Any], logging.Logger],
+    Tuple[xr.Dataset, str],
+]
+
+_STEP_REGISTRY: list[Tuple[int, str, StepFn]] = []
+
+
+def register_step(name: str, order: int) -> Callable[[StepFn], StepFn]:
+    """Register a preprocessing step so ``_apply_preprocessing`` runs it.
+
+    Args:
+        name (str): Unique step name (matches its settings key).
+        order (int): Execution order; steps with a lower value run first.
+
+    Returns:
+        Callable[[StepFn], StepFn]: Decorator that records the step.
+    """
+
+    def decorator(fn: StepFn) -> StepFn:
+        _STEP_REGISTRY.append((order, name, fn))
+        return fn
+
+    return decorator
+
+
+def _apply_simple_step(
+    ds: xr.Dataset,
+    fname_base: str,
+    *,
+    enabled: bool,
+    present: bool,
+    message: str,
+    transform: Callable[[xr.Dataset], xr.Dataset],
+    suffix: str | None,
+    logger: logging.Logger,
+) -> Tuple[xr.Dataset, str]:
+    """Run a step following the flag/condition/transform/suffix pattern.
+
+    Args:
+        ds (xr.Dataset): Dataset to transform.
+        fname_base (str): Current file name base.
+        enabled (bool): Whether the step is turned on in the settings.
+        present (bool): Whether the target variable/coordinate exists.
+        message (str): Log message emitted when the step runs.
+        transform (Callable[[xr.Dataset], xr.Dataset]): Transformation to apply.
+        suffix (str | None): Filename suffix appended on success.
+        logger (logging.Logger): Logger for progress messages.
+
+    Returns:
+        Tuple[xr.Dataset, str]: Updated dataset and file name base.
+    """
+    if not (enabled and present):
+        return ds, fname_base
+    logger.info(message)
+    ds = transform(ds)
+    if suffix:
+        fname_base += f"_{suffix}"
+    return ds, fname_base
+
+
+@register_step("unify_coords", order=10)
+def _step_unify_coords(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Rename coordinates to unify them across datasets."""
+    return _apply_simple_step(
+        ds,
+        fname_base,
+        enabled=s.get("unify_coords", False),
+        present=True,
+        message="Renaming coordinates to unify them across datasets...",
+        transform=lambda d: rename_coords(d, s.get("uni_coords")),
+        suffix=s.get("unify_coords_fname"),
+        logger=logger,
+    )
+
+
+@register_step("adjust_longitude", order=20)
+def _step_adjust_longitude(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Adjust longitude from 0-360 to -180-180 (full map only)."""
+    vname = s.get("adjust_longitude_vname")
+    return _apply_simple_step(
+        ds,
+        fname_base,
+        enabled=s.get("adjust_longitude", False),
+        present=vname in ds.coords,
+        message="Adjusting longitude from 0-360 to -180-180...",
+        # only consider full map for now, i.e. limited_area=False
+        transform=lambda d: adjust_longitude_360_to_180(d, lon_name=vname),
+        suffix=s.get("adjust_longitude_fname"),
+        logger=logger,
+    )
+
+
+@register_step("convert_kelvin_to_celsius", order=30)
+def _step_convert_kelvin_to_celsius(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Convert temperature from Kelvin to Celsius."""
+    vname = s.get("convert_kelvin_to_celsius_vname")
+    return _apply_simple_step(
+        ds,
+        fname_base,
+        enabled=s.get("convert_kelvin_to_celsius", False),
+        present=vname in ds.data_vars,
+        message="Converting temperature from Kelvin to Celsius...",
+        transform=lambda d: convert_to_celsius_with_attributes(d, var_name=vname),
+        suffix=s.get("convert_kelvin_to_celsius_fname"),
+        logger=logger,
+    )
+
+
+@register_step("convert_m_to_mm_precipitation", order=40)
+def _step_convert_m_to_mm_precipitation(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Convert precipitation from meters to millimeters."""
+    vname = s.get("convert_m_to_mm_precipitation_vname")
+    return _apply_simple_step(
+        ds,
+        fname_base,
+        enabled=s.get("convert_m_to_mm_precipitation", False),
+        present=vname in ds.data_vars,
+        message="Converting precipitation from meters to millimeters...",
+        transform=lambda d: convert_m_to_mm_with_attributes(d, var_name=vname),
+        suffix=s.get("convert_m_to_mm_precipitation_fname"),
+        logger=logger,
+    )
+
+
+@register_step("cal_monthly_tp", order=45)
+def _step_cal_monthly_tp(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Calculate monthly total precipitation from downloaded monthly data."""
+    vname = s.get("cal_monthly_tp_vname")
+    tcoord = s.get("cal_monthly_tp_tcoord")
+    return _apply_simple_step(
+        ds,
+        fname_base,
+        enabled=s.get("cal_monthly_tp", False),
+        present=all((vname in ds.data_vars, tcoord in ds.coords)),
+        message=(
+            "Calculating monthly total precipitation = "
+            "downloaded data * number of days in month..."
+        ),
+        transform=lambda d: calculate_monthly_precipitation(
+            d, var_name=vname, time_coord=tcoord
+        ),
+        suffix=s.get("cal_monthly_tp_fname"),
+        logger=logger,
+    )
+
+
+@register_step("resample_grid", order=50)
+def _step_resample_grid(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Resample the grid to a new resolution (multi-library step)."""
+    resample_grid_vname = s.get("resample_grid_vname")
+    lat_name, lon_name = resample_grid_vname if resample_grid_vname else (None, None)
+    enabled = s.get("resample_grid", False)
+    if not (enabled and all((lat_name in ds.coords, lon_name in ds.coords))):
+        return ds, fname_base
+
+    logger.info("Resampling grid to a new resolution...")
+    resample_degree = s.get("resample_degree")
+    ds = resample_resolution(
+        ds,
+        resolution_config=ResolutionConfig(
+            new_resolution=resample_degree,
+            lat_name=lat_name,
+            lon_name=lon_name,
+            downsample_lib=s.get("downsample_lib", "xesmf"),
+            downsample_agg_funcs=s.get("downsample_agg_funcs", None),
+            upsample_method_map=s.get("upsample_method_map", None),
+        ),
+        grid_config=GridConfig(
+            expected_longitude_max_xarray=s.get(
+                "downsample_max_lon_xarray", np.float64(179.75)
+            ),
+            new_min_lat=s.get("downsample_new_min_lat", None),
+            new_max_lat=s.get("downsample_new_max_lat", None),
+            new_min_lon=s.get("downsample_new_min_lon", None),
+            new_max_lon=s.get("downsample_new_max_lon", None),
+            new_lat_size=s.get("downsample_new_lat_size", None),
+            new_lon_size=s.get("downsample_new_lon_size", None),
+            gridtype=s.get("downsample_gridtype", "lonlat"),
+        ),
+    )
+    degree_str = _replace_decimal_point(resample_degree)
+    fname_base += f"_{degree_str}{s.get('resample_grid_fname')}"
+    return ds, fname_base
+
+
+@register_step("truncate_date", order=60)
+def _step_truncate_date(
+    ds: xr.Dataset, fname_base: str, s: Dict[str, Any], logger: logging.Logger
+) -> Tuple[xr.Dataset, str]:
+    """Truncate the time series to a date range."""
+    truncate_date_vname = s.get("truncate_date_vname")
+    if not (s.get("truncate_date", False) and truncate_date_vname in ds.coords):
+        return ds, fname_base
+
+    logger.info("Truncating data from a specific start date...")
+    truncate_date_from = s.get("truncate_date_from")
+    truncate_date_to = s.get("truncate_date_to")
+    ds = truncate_data_by_time(
+        ds,
+        start_date=truncate_date_from,
+        end_date=truncate_date_to,
+        var_name=truncate_date_vname,
+    )
+
+    min_year = truncate_date_from[:4]
+    max_time = ds[truncate_date_vname].max().values
+    end_date = truncate_date_to or max_time
+    max_year = np.datetime64(end_date, "Y")
+    fname_base += f"_{min_year}-{max_year}"
+    return ds, fname_base
+
+
 def _apply_preprocessing(
     dataset: xr.Dataset,
     file_name_base: str,
     settings: Dict[str, Any],
 ) -> Tuple[xr.Dataset, str]:
-    """Apply preprocessing steps to the dataset based on settings.
+    """Apply registered preprocessing steps to the dataset based on settings.
+
+    Steps run in ascending order of their ``register_step`` ``order`` value,
+    which determines both execution sequence and the order of filename
+    suffixes.
 
     Args:
         dataset (xr.Dataset): Dataset to preprocess.
@@ -1152,186 +1389,8 @@ def _apply_preprocessing(
     Returns:
         Tuple[xr.Dataset, str]: Preprocessed dataset and updated file name.
     """
-    # get settings
-    unify_coords = settings.get("unify_coords", False)
-    unify_coords_fname = settings.get("unify_coords_fname")
-    uni_coords = settings.get("uni_coords")
-
-    adjust_longitude = settings.get("adjust_longitude", False)
-    adjust_longitude_vname = settings.get("adjust_longitude_vname")
-    adjust_longitude_fname = settings.get("adjust_longitude_fname")
-
-    convert_kelvin_to_celsius = settings.get("convert_kelvin_to_celsius", False)
-    convert_kelvin_to_celsius_vname = settings.get("convert_kelvin_to_celsius_vname")
-    convert_kelvin_to_celsius_fname = settings.get("convert_kelvin_to_celsius_fname")
-
-    convert_m_to_mm_precipitation = settings.get("convert_m_to_mm_precipitation", False)
-    convert_m_to_mm_precipitation_vname = settings.get(
-        "convert_m_to_mm_precipitation_vname"
-    )
-    convert_m_to_mm_precipitation_fname = settings.get(
-        "convert_m_to_mm_precipitation_fname"
-    )
-
-    resample_grid = settings.get("resample_grid", False)
-    resample_grid_vname = settings.get("resample_grid_vname")
-    lat_name, lon_name = resample_grid_vname if resample_grid_vname else (None, None)
-    resample_grid_fname = settings.get("resample_grid_fname")
-    resample_degree = settings.get("resample_degree")
-    downsample_agg_funcs = settings.get("downsample_agg_funcs", None)
-    upsample_method_map = settings.get("upsample_method_map", None)
-    resample_expected_longitude_max = settings.get(
-        "downsample_max_lon_xarray", np.float64(179.75)
-    )
-    downsample_lib = settings.get("downsample_lib", "xesmf")
-    new_min_lat = settings.get("downsample_new_min_lat", None)
-    new_max_lat = settings.get("downsample_new_max_lat", None)
-    new_min_lon = settings.get("downsample_new_min_lon", None)
-    new_max_lon = settings.get("downsample_new_max_lon", None)
-    new_lat_size = settings.get("downsample_new_lat_size", None)
-    new_lon_size = settings.get("downsample_new_lon_size", None)
-    gridtype = settings.get("downsample_gridtype", "lonlat")
-
-    truncate_date = settings.get("truncate_date", False)
-    truncate_date_from = settings.get("truncate_date_from")
-    truncate_date_to = settings.get("truncate_date_to")
-    truncate_date_vname = settings.get("truncate_date_vname")
-
-    cal_monthly_tp = settings.get("cal_monthly_tp", False)
-    cal_monthly_tp_vname = settings.get("cal_monthly_tp_vname")
-    cal_monthly_tp_tcoord = settings.get("cal_monthly_tp_tcoord")
-    cal_monthly_tp_fname = settings.get("cal_monthly_tp_fname")
-
-    # define helper function
-    def apply_step(
-        ds: xr.Dataset,
-        fname_base: str,
-        step: Dict[str, Any],
-        logger: logging.Logger,
-    ) -> Tuple[xr.Dataset, str]:
-        """Apply a preprocessing step to the dataset and update the file name."""
-        if not step["condition"](ds):
-            return ds, fname_base
-
-        logger.info(step["message"])
-        ds = step["transform"](ds)
-
-        suffix = step.get("suffix")
-
-        if suffix:
-            fname_base += f"_{suffix}"
-
-        return ds, fname_base
-
-    # define steps with common structure
-    pp_common_steps = [
-        {
-            "condition": lambda ds: unify_coords,
-            "message": "Renaming coordinates to unify them across datasets...",
-            "transform": lambda ds: rename_coords(ds, uni_coords),
-            "suffix": unify_coords_fname,
-        },
-        {
-            "condition": lambda ds: (
-                adjust_longitude and adjust_longitude_vname in ds.coords
-            ),
-            "message": "Adjusting longitude from 0-360 to -180-180...",
-            "transform": lambda ds: adjust_longitude_360_to_180(
-                ds, lon_name=adjust_longitude_vname
-            ),  # only consider full map for now, i.e. limited_area=False
-            "suffix": adjust_longitude_fname,
-        },
-        {
-            "condition": lambda ds: (
-                convert_kelvin_to_celsius
-                and convert_kelvin_to_celsius_vname in ds.data_vars
-            ),
-            "message": "Converting temperature from Kelvin to Celsius...",
-            "transform": lambda ds: convert_to_celsius_with_attributes(
-                ds, var_name=convert_kelvin_to_celsius_vname
-            ),
-            "suffix": convert_kelvin_to_celsius_fname,
-        },
-        {
-            "condition": lambda ds: (
-                convert_m_to_mm_precipitation
-                and convert_m_to_mm_precipitation_vname in ds.data_vars
-            ),
-            "message": "Converting precipitation from meters to millimeters...",
-            "transform": lambda ds: convert_m_to_mm_with_attributes(
-                ds, var_name=convert_m_to_mm_precipitation_vname
-            ),
-            "suffix": convert_m_to_mm_precipitation_fname,
-        },
-        {
-            "condition": lambda ds: (
-                cal_monthly_tp
-                and all(
-                    (
-                        cal_monthly_tp_vname in ds.data_vars,
-                        cal_monthly_tp_tcoord in ds.coords,
-                    )
-                )
-            ),
-            "message": (
-                "Calculating monthly total precipitation = "
-                "downloaded data * number of days in month..."
-            ),
-            "transform": lambda ds: calculate_monthly_precipitation(
-                ds,
-                var_name=cal_monthly_tp_vname,
-                time_coord=cal_monthly_tp_tcoord,
-            ),
-            "suffix": cal_monthly_tp_fname,
-        },
-    ]
-
-    # apply common steps
-    for step in pp_common_steps:
-        dataset, file_name_base = apply_step(dataset, file_name_base, step, logger)
-
-    # handle complex steps separately
-    if resample_grid and all((lat_name in dataset.coords, lon_name in dataset.coords)):
-        logger.info("Resampling grid to a new resolution...")
-        dataset = resample_resolution(
-            dataset,
-            resolution_config=ResolutionConfig(
-                new_resolution=resample_degree,
-                lat_name=lat_name,
-                lon_name=lon_name,
-                downsample_lib=downsample_lib,
-                downsample_agg_funcs=downsample_agg_funcs,
-                upsample_method_map=upsample_method_map,
-            ),
-            grid_config=GridConfig(
-                expected_longitude_max_xarray=resample_expected_longitude_max,
-                new_min_lat=new_min_lat,
-                new_max_lat=new_max_lat,
-                new_min_lon=new_min_lon,
-                new_max_lon=new_max_lon,
-                new_lat_size=new_lat_size,
-                new_lon_size=new_lon_size,
-                gridtype=gridtype,
-            ),
-        )
-        degree_str = _replace_decimal_point(resample_degree)
-        file_name_base += f"_{degree_str}{resample_grid_fname}"
-
-    if truncate_date and truncate_date_vname in dataset.coords:
-        logger.info("Truncating data from a specific start date...")
-        dataset = truncate_data_by_time(
-            dataset,
-            start_date=truncate_date_from,
-            end_date=truncate_date_to,
-            var_name=truncate_date_vname,
-        )
-
-        min_year = truncate_date_from[:4]
-        max_time = dataset[truncate_date_vname].max().values
-        end_date = truncate_date_to or max_time
-        max_year = np.datetime64(end_date, "Y")
-        file_name_base += f"_{min_year}-{max_year}"
-
+    for _order, _name, step_fn in sorted(_STEP_REGISTRY, key=lambda item: item[0]):
+        dataset, file_name_base = step_fn(dataset, file_name_base, settings, logger)
     return dataset, file_name_base
 
 

--- a/heiplanet_data/test/test_preprocess.py
+++ b/heiplanet_data/test/test_preprocess.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import xarray as xr
-from heiplanet_data import preprocess
+from heiplanet_data import preprocess, utils
 import geopandas as gpd
 from shapely.geometry import Polygon
 from pathlib import Path
@@ -2324,11 +2324,13 @@ def test_apply_preprocessing_wind_height_unchanged():
 
 
 def test_registered_steps_have_schema_entries():
-    """Guard the registry<->schema link.
+    """Guard the registry<->schema link in both directions.
 
     Every preprocessing step registered via ``preprocess.register_step`` must
     have a matching enable-flag property in ``setting_schema.json``, so a newly
-    added step cannot silently drift from its configuration schema. Also check
+    added step cannot silently drift from its configuration schema. Conversely,
+    every boolean enable-flag in the schema must have a registered step, so a
+    flag cannot be added to the schema without wiring up its step. Also check
     that step order values are unique, keeping the execution sequence
     deterministic.
     """
@@ -2336,10 +2338,38 @@ def test_registered_steps_have_schema_entries():
     schema_path = resources.files("heiplanet_data") / "setting_schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     schema_props = set(schema["properties"])
+    schema_flags = {
+        name
+        for name, spec in schema["properties"].items()
+        if spec.get("type") == "boolean"
+    }
 
-    step_names = [name for _order, name, _fn in preprocess._STEP_REGISTRY]
-    missing = [name for name in step_names if name not in schema_props]
-    assert not missing, f"registered steps missing from schema: {missing}"
+    step_names = {name for _order, name, _fn in preprocess._STEP_REGISTRY}
+
+    missing = step_names - schema_props
+    assert not missing, f"registered steps missing from schema: {sorted(missing)}"
+
+    orphan_flags = schema_flags - step_names
+    assert not orphan_flags, (
+        f"schema enable-flags without a registered step: {sorted(orphan_flags)}"
+    )
 
     orders = [order for order, _name, _fn in preprocess._STEP_REGISTRY]
     assert len(orders) == len(set(orders)), f"duplicate step order values: {orders}"
+
+
+@pytest.mark.parametrize("source", ["era5", "isimip"])
+def test_shipped_settings_files_validate_against_schema(source):
+    """Regression guard: shipped default settings files honour the schema.
+
+    Each default settings JSON (``era5_settings.json``, ``isimip_settings.json``)
+    must validate against ``setting_schema.json``, so an edit that introduces an
+    unknown key, a wrong type, or a missing conditionally-required field is
+    caught here instead of at runtime.
+    """
+
+    setting_path = utils.DEFAULT_SETTINGS_FILE[source]
+    settings = json.loads(setting_path.read_text(encoding="utf-8"))
+    assert utils.is_valid_settings(settings), (
+        f"shipped settings file {setting_path} does not validate against schema"
+    )

--- a/heiplanet_data/test/test_preprocess.py
+++ b/heiplanet_data/test/test_preprocess.py
@@ -12,6 +12,7 @@ import xesmf as xe
 from cdo import Cdo
 import textwrap
 import pandas as pd
+from importlib import resources
 
 
 @pytest.fixture()
@@ -2331,7 +2332,6 @@ def test_registered_steps_have_schema_entries():
     that step order values are unique, keeping the execution sequence
     deterministic.
     """
-    from importlib import resources
 
     schema_path = resources.files("heiplanet_data") / "setting_schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))

--- a/heiplanet_data/test/test_preprocess.py
+++ b/heiplanet_data/test/test_preprocess.py
@@ -2320,3 +2320,26 @@ def test_apply_preprocessing_wind_height_unchanged():
     # check if height is unchanged
     assert "new_height" in preprocessed_dataset.coords
     assert np.array_equal(preprocessed_dataset["new_height"].values, org_height)
+
+
+def test_registered_steps_have_schema_entries():
+    """Guard the registry<->schema link.
+
+    Every preprocessing step registered via ``preprocess.register_step`` must
+    have a matching enable-flag property in ``setting_schema.json``, so a newly
+    added step cannot silently drift from its configuration schema. Also check
+    that step order values are unique, keeping the execution sequence
+    deterministic.
+    """
+    from importlib import resources
+
+    schema_path = resources.files("heiplanet_data") / "setting_schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema_props = set(schema["properties"])
+
+    step_names = [name for _order, name, _fn in preprocess._STEP_REGISTRY]
+    missing = [name for name in step_names if name not in schema_props]
+    assert not missing, f"registered steps missing from schema: {missing}"
+
+    orders = [order for order, _name, _fn in preprocess._STEP_REGISTRY]
+    assert len(orders) == len(set(orders)), f"duplicate step order values: {orders}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "xagg",
   "exactextract",
   "rioxarray",
+  "jsonschema",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ cdo
 xagg
 exactextract
 rioxarray
+jsonschema


### PR DESCRIPTION
This PR changes the way the different preprocessing steps are triggered and how data is passed.

Previously, `pp_common_steps` hardwired the different functions to use in the preprocessing into the workflow via lambda functions. This meant that all the variables are only known locally to the function and need to be defined in this spot, so adding a new preprocessing step required changes in many different places.

The refactored version uses decorators in a registry, which allows variables to be defined upon calling of the function, so at the place of the preprocessing step and not at the orchestration step.

This simplifies the preprocessing internal workflow and makes it easier to add (register) new preprocessing methods.

In a subsequent PR, the ultralong `preprocess` and its test module will be separated out.